### PR TITLE
added discounted price to product pages

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -228,7 +228,15 @@ button {
     font-size: inherit;
     grid-template-columns: 150px auto 15%;
   }
+
 }
+#productDiscount {
+  font-size: 1.2em; 
+  color: black; 
+  font-weight: bold;
+  margin-top: 10px;
+}
+
 
 footer {
   font-size: var(--small-font);

--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -30,17 +30,40 @@ function addToCart() {
 
 function renderProductDetails() {
   document.querySelector("#productName").innerText = product.Brand.Name;
-  document.querySelector("#productNameWithoutBrand").innerText =
-    product.NameWithoutBrand;
+  document.querySelector("#productNameWithoutBrand").innerText = product.NameWithoutBrand;
   document.querySelector("#productImage").src = product.Image;
   document.querySelector("#productImage").alt = product.Name;
-  document.querySelector("#productFinalPrice").innerText = product.FinalPrice;
-  document.querySelector("#productColorName").innerText =
-    product.Colors[0].ColorName;
-  document.querySelector("#productDescriptionHtmlSimple").innerHTML =
-    product.DescriptionHtmlSimple;
+
+  const priceElement = document.querySelector("#productFinalPrice");
+
+  if (product.Discount !== undefined) {
+    // Display the discount amount and percentage
+    const discountElement = document.createElement("p");
+    discountElement.id = "productDiscount";
+    discountElement.innerHTML = `Discount: $${product.Discount.Amount} (${product.Discount.Percent}%)`;
+    discountElement.classList.add("discount");
+
+    // Append the discountElement to the product-detail section
+    document.querySelector(".product-detail").appendChild(discountElement);
+
+    // Cross out the original price
+    priceElement.style.textDecoration = "line-through";
+
+    // Calculate and display the discounted price
+    const discountedPrice = product.FinalPrice - product.Discount.Amount;
+    const discountedPriceElement = document.createElement("p");
+    discountedPriceElement.innerHTML = `Discounted Price: $${discountedPrice.toFixed(2)}`;
+    priceElement.insertAdjacentElement("afterend", discountedPriceElement);
+  }
+
+  document.querySelector("#productColorName").innerText = product.Colors[0].ColorName;
+  document.querySelector("#productDescriptionHtmlSimple").innerHTML = product.DescriptionHtmlSimple;
   document.querySelector("#addToCart").dataset.id = product.Id;
 }
+
+
+
+
 // function displayProductNotFoundError(showError) {
 //   // Display or hide the error message based on the 'showError' parameter
 //   const errorMessageElement = document.getElementById("errorMessage");
@@ -55,3 +78,4 @@ function renderProductDetails() {
 //   errorMessageElement.innerText = errorMessage;
 //   errorMessageElement.style.display = "block";
 // }
+ 

--- a/src/product_pages/cedar-ridge-rimrock-2.html
+++ b/src/product_pages/cedar-ridge-rimrock-2.html
@@ -74,7 +74,6 @@
           Lightweight and ready for adventure, this Cedar Ridge Rimrock tent
           boasts a weather-ready design that includes a tub-style floor and
           factory-sealed rain fly
-        </p>
 
         <div class="product-detail__add">
           <button id="addToCart" data-id="344YJ">Add to Cart</button>

--- a/src/product_pages/index.html
+++ b/src/product_pages/index.html
@@ -19,7 +19,10 @@
         <h3 id="productName"></h3>
         <h2 class="divider" id="productNameWithoutBrand"></h2>
         <img id="productImage" class="divider" src="" alt="" />
-        <p class="product-card__price" id="productFinalPrice"></p>
+        <p class="product-card__price" id="productFinalPrice"></p>              
+        <p class="product-card__discount-price" id="productDiscount"> 
+       </p>
+
         <p class="product__color" id="productColorName"></p>
         <p class="product__description" id="productDescriptionHtmlSimple"></p>
         <div class="product-detail__add">

--- a/src/public/json/tents.json
+++ b/src/public/json/tents.json
@@ -74,7 +74,6 @@
     "Name": "Cedar Ridge Rimrock Tent - 2-Person, 3-Season",
     "IsFamousBrand": false,
     "Image": "../images/tents/cedar-ridge-rimrock-tent-2-person-3-season-in-rust-clay~p~344yj_01~320.jpg",
-
     "SizesAvailable": {},
     "Colors": [
       {
@@ -82,15 +81,20 @@
         "ColorName": "Rust/Clay"
       }
     ],
-    "DescriptionHtmlSimple": "<strong><a class=\"glossaryTermLink\" href=\"/closeouts~g~2312\" title=\"Closeouts: - Closeouts are items that may be last year's model or color. While closeout items are often offered at discounted prices, the products themselves are always high quality. Closeout items can include anything from shoes, underwear and apparel, to rugs, tents and outdoor equipment. Closeouts are often a high percentage off the retail price.\">Closeouts</a></strong>. Lightweight and ready for adventure, this Cedar Ridge Rimrock tent boasts a weather-ready design that includes a tub-style floor and factory-sealed <a class=\"glossaryTermLink\" href=\"/rain-fly~g~2021\" title=\"Rain Fly: - Rain fly is an additional piece of fabric (attached or unattached) that is placed over the top of the tent to provide weatherproofness. The rain fly is usually made of polyester or nylon and is sometimes coated for additional water repellency.\">rain fly</a>.",
+    "DescriptionHtmlSimple": "Lightweight and ready for adventure...",
     "SuggestedRetailPrice": 89.99,
     "Brand": {
       "Id": "35027",
       "Name": "Cedar Ridge"
     },
     "ListPrice": 69.99,
-    "FinalPrice": 69.99
+    "FinalPrice": 69.99,
+    "Discount": {
+      "Amount": 6.99, 
+      "Percent": 10 
+    }
   },
+  
   {
     "Id": "989CG",
     "NameWithoutBrand": "Talus Tent - 3-Person, 3-Season",


### PR DESCRIPTION
If you go to the Rimrock Tent product page you will see the discount amount, discount percentage and the new discounted price in place of the old price.  I tried to get a strike thru of the original price but couldn't get that to work. I think this will work though.  If it looks good, will you please merge it?